### PR TITLE
Update translationManager.mjs so it works with the new translation system

### DIFF
--- a/Construction/src/language/translationManager.mjs
+++ b/Construction/src/language/translationManager.mjs
@@ -52,11 +52,22 @@ export function templateRielkLangStringWithNodes(id, nodeData, textData, clone=t
 }
 
 export function patchTranslations(ctx) {
-    const superSetLanguage = setLanguage;
-    setLanguage = (...args) => {
-        superSetLanguage(...args);
-        tm.syncLang();
+    if (typeof setLanguage === "function") {
+        const superSetLanguage = setLanguage;
+        setLanguage = (...args) => {
+            superSetLanguage(...args);
+            if (tm && typeof tm.syncLang === "function") tm.syncLang();
+        };
     }
+    else if (typeof saveAndLoadLanguage === "function") { 
+        const superSaveAndLoadLanguage = saveAndLoadLanguage;
+        saveAndLoadLanguage = (...args) => {
+            const result = superSaveAndLoadLanguage(...args);
+            if (tm && typeof tm.syncLang === "function") tm.syncLang();
+            return result;
+        };
+    }
+
 
     const superUpdateUIForLanguageChange = updateUIForLanguageChange;
     updateUIForLanguageChange = (...args) => {
@@ -67,6 +78,7 @@ export function patchTranslations(ctx) {
                 langStrings[i].updateTranslation();
             }
         }
+
     }
 
     ctx.patch(Item, 'name').get(function (patch) {


### PR DESCRIPTION
Mod currently works, this is a change for the coming changes in the setLanguage script for the offline client (which is currently only in beta)

Currently the mod throws an error since setLanguage isn't a function in the new translationManager, this hooks into the correct function if the game is ran on the offline client. Also useful if the offline client changes ever come to the normal client.