### PR TITLE
Fix FixtureRecipe counting as MasteryActions

### DIFF
--- a/Construction/src/construction/construction.mjs
+++ b/Construction/src/construction/construction.mjs
@@ -176,6 +176,20 @@ export class Construction extends ArtisanSkill {
         }
         );
     }
+    computeTotalMasteryActions() {
+        this.actions.namespaceMaps.forEach((actionMap, namespace) => {
+            let total = 0;
+            actionMap.forEach((action) => {
+                const id = action.id || "(no id)";
+                const cat = action.category?.type || "(no category)";
+                if (action.hasMastery) {
+                    if (!action.realm?.ignoreCompletion) total++;
+                    if (action.realm) this.totalMasteryActionsInRealm.inc(action.realm);
+                }
+            });
+            this.totalMasteryActions.set(namespace, total);
+        });
+    }
     postDataRegistration() {
         super.postDataRegistration();
         this.sortedMasteryActions = sortRecipesByCategoryAndLevel(this.actions.allObjects.filter(act => act.category.type === 'Artisan'), this.categories.allObjects);

--- a/Construction/src/construction/constructionFixtureRecipes.mjs
+++ b/Construction/src/construction/constructionFixtureRecipes.mjs
@@ -6,6 +6,7 @@ const { templateRielkLangString } = await loadModule('src/language/translationMa
 export class ConstructionFixtureRecipes extends CategorizedArtisanRecipe {
     constructor(namespace, data, game, skill) {
         super(namespace, data, game, skill);
+        this.hasMastery = false;
         try {
             this._baseActionCost = data.baseActionCost;
             this.modifiers = new ConstructionModifiers(data, game, `${this.id}`);

--- a/Construction/src/construction/constructionRecipe.mjs
+++ b/Construction/src/construction/constructionRecipe.mjs
@@ -1,6 +1,7 @@
 export class ConstructionRecipe extends SingleProductArtisanSkillRecipe {
     constructor(namespace, data, game, skill) {
         super(namespace, data, game, skill);
+        this.hasMastery = true;
         try {
         } catch (e) {
             throw new DataConstructionError(ConstructionRecipe.name, e, this.id);


### PR DESCRIPTION
Simple fix script to make sure FixtureRecipe elements aren't counted as being mastery-able for the purposes of counting total Mastery levels (such as in the completion log, mastery pool XP, and mastery token drop rate).