### PR TITLE
Update construction-styles.css

### DIFF
--- a/Construction/src/interface/construction-styles.css
+++ b/Construction/src/interface/construction-styles.css
@@ -2,7 +2,7 @@ body.darkMode .bg-rielk-construction,.bg-rielk-construction {
     background-color: #e7874f!important
 }
 
-.bg-rielk-construction-50 {
+.bg-construction-50 {
     background-color: #e7874f3d!important
 }
 


### PR DESCRIPTION
setSkill uses the skill's localID, so using the entire ID doesn't work. This will apply the color on the on the completion's mastery and skill log